### PR TITLE
Fix #2 - Wrong intendation breaks build

### DIFF
--- a/libnuml/src/bindings/python/local.i
+++ b/libnuml/src/bindings/python/local.i
@@ -702,7 +702,7 @@ NUMLReader::readNUMLFromFile(const std::string&)
 
     Parameter 'filename is the name or full pathname of the file to be
     read.
-getElementName()
+    getElementName()
     Returns a pointer to the NUMLDocument created from the NUML content.
 
     See also NUMLError.


### PR DESCRIPTION
I also run into #2 on linux. This fixes the build.
If local.i is generated from some other file the origin of the issue should be fixed.