### PR TITLE
Fix for building with libSBML namespaces enabled

### DIFF
--- a/libnuml/src/numl/NMBase.cpp
+++ b/libnuml/src/numl/NMBase.cpp
@@ -47,6 +47,7 @@
 #include <numl/AtomicValue.h>
 
 using namespace std;
+LIBSBML_CPP_NAMESPACE_USE
 
 LIBNUML_CPP_NAMESPACE_BEGIN
 

--- a/libnuml/src/numl/NMBase.h
+++ b/libnuml/src/numl/NMBase.h
@@ -635,24 +635,24 @@ public:
   void syncAnnotation();
   bool isSetNotes() const;
   bool isSetAnnotation() const;
-  virtual int setAnnotation(const XMLNode* annotation);
+  virtual int setAnnotation(const LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode* annotation);
   virtual int setAnnotation(const std::string& annotation);
-  virtual int appendAnnotation(const XMLNode* annotation);
+  virtual int appendAnnotation(const LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode* annotation);
   virtual int appendAnnotation(const std::string& annotation);
   int removeTopLevelAnnotationElement(const std::string elementName,
                                       const std::string elementURI = "");
-  int replaceTopLevelAnnotationElement(const XMLNode* annotation);
+  int replaceTopLevelAnnotationElement(const LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode* annotation);
   int replaceTopLevelAnnotationElement(const std::string& annotation);
-  int setNotes(const XMLNode* notes);
+  int setNotes(const LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode* notes);
   int setNotes(const std::string& notes, bool addXHTMLMarkup = false);
-  int appendNotes(const XMLNode* notes);
+  int appendNotes(const LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode* notes);
   int appendNotes(const std::string& notes);
   int unsetNotes();
   int unsetAnnotation();
 
-  XMLNode* getNotes() const;
+  LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode* getNotes() const;
   std::string getNotesString() const;
-  XMLNode* getAnnotation() const;
+  LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode* getAnnotation() const;
   std::string getAnnotationString() const;
 
 


### PR DESCRIPTION
This is just a fixed version of my PR #13 with newline changes removed. Sorry for the double post.

I'm trying to build libnuml (and its Python bindings) with namespaces enabled. I'm also compiling against libSBML with namespaces enabled per [our conversation here](https://github.com/fbergmann/libSEDML/issues/44#issuecomment-331362578). I ran into a small number of cases where class names inside libSBML (like XMLNode etc.) were not resolved. In this pull request, I simply added the libSBML namespace qualifiers to NMBase.h and a using directive to NMBase.cpp.