### PR TITLE
Fix installation with python 3.10+

### DIFF
--- a/libnuml/src/bindings/python/CMakeLists.txt
+++ b/libnuml/src/bindings/python/CMakeLists.txt
@@ -153,7 +153,7 @@ endif()
 #
 set(PYTHON_PACKAGE_INSTALL_DIR)
 if (UNIX OR CYGWIN) 
-  execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "import sys;import platform; sys.stdout.write(platform.python_version()[:3])"
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "import sys;import platform; sys.stdout.write(platform.python_version().rsplit('.', 1)[0])"
     OUTPUT_VARIABLE PYTHON_VERSION)
   set(PYTHON_PACKAGE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION}/site-packages)
 else()


### PR DESCRIPTION
With two digit minor version of python (3.10) the code which is intended to return MAJOR.MINOR by taking first three characters no longer works correctly. Cut off the last dot-separated component instead.